### PR TITLE
expose Extensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,5 @@ pub use types::{
   TargetEnv,
   EsResolverError,
   EsResolveOptions,
+  Extensions
 };


### PR DESCRIPTION
Extensions type is needed in order to create an EsResolver with modified EsResolverOptions::extensions.